### PR TITLE
add modify links on copy command feauture

### DIFF
--- a/src/copy.js
+++ b/src/copy.js
@@ -1,30 +1,45 @@
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action == 'modify-link') {
     const clipboardData = request.data;
-    var modifiedLink = clipboardData.replace('twitter', 'vxtwitter');
-
-    chrome.storage.sync.get('fxenabled', isFxEnabled => {
-      console.log(isFxEnabled);
-      if (
-        isFxEnabled != null &&
-        isFxEnabled.fxenabled != undefined &&
-        isFxEnabled.fxenabled
-      ) {
-        modifiedLink = clipboardData.replace('twitter', 'fxtwitter');
-      }
-
-      navigator.clipboard.writeText(modifiedLink).then(
-        () => {
-          console.log(
-            'Modified twitter link successfully copied to clipboard.'
-          );
-        },
-        err => {
-          console.log('Unable to modify the twitter link.', err);
-        }
-      );
-    });
+    updateLink(clipboardData);
   } else {
     console.log('Unknown action received.');
   }
 });
+
+document.addEventListener('copy', e => {
+  currentLink = document.location.href;
+
+  chrome.storage.sync.get('oncopyenabled', isOnCopyEnabled => {
+    if (
+      isOnCopyEnabled != null &&
+      isOnCopyEnabled.oncopyenabled != undefined &&
+      isOnCopyEnabled.oncopyenabled
+    ) {
+      updateLink(currentLink);
+    }
+  });
+});
+
+const updateLink = clipboardData => {
+  var modifiedLink = clipboardData.replace('twitter', 'vxtwitter');
+
+  chrome.storage.sync.get('fxenabled', isFxEnabled => {
+    if (
+      isFxEnabled != null &&
+      isFxEnabled.fxenabled != undefined &&
+      isFxEnabled.fxenabled
+    ) {
+      modifiedLink = clipboardData.replace('twitter', 'fxtwitter');
+    }
+
+    navigator.clipboard.writeText(modifiedLink).then(
+      () => {
+        console.log('Modified twitter link successfully copied to clipboard.');
+      },
+      err => {
+        console.log('Unable to modify the twitter link.', err);
+      }
+    );
+  });
+};

--- a/src/popup.html
+++ b/src/popup.html
@@ -75,7 +75,7 @@
             border-bottom: #fff solid 2px;
         }
 
-        .fxtwitter-toggle{
+        .options-toggle{
             display: flex;
             justify-content: center;
             align-items: center;
@@ -101,6 +101,7 @@
 
         .toggles{
             display: flex;
+            flex-direction: column;
             justify-content: center;
             align-items: center;
         }
@@ -110,7 +111,7 @@
             height: 100%;
         }
 
-        .fx-enable{
+        .toggle-enable{
             margin: 0px 10px 0px 0px;
             font-size: small;
             font-weight: 500;
@@ -119,19 +120,23 @@
         .toggle-wrap{
             display: flex;
             flex-direction: column;
-            
+            margin-bottom: 10px;
             border-left: 2px solid rgb(255, 255, 255, 0.08);
             border-right: 2px solid rgb(255, 255, 255, 0.08);
             border-bottom: 2px solid rgb(255, 255, 255, 0.08);
             border-radius: 10px;
         }
-        .fx-description{
+        .toggle-description{
             display: flex;
             height:40px;
             align-items: center;
             font-size: 12px;
             padding: 5px 15px 5px 15px;
             color: rgba(255, 255, 255, 0.5);
+        }
+
+        .oncopy-description{
+            height: 60px !important;
         }
 
     </style>
@@ -144,18 +149,29 @@
         </div>
         <div class="center toggles">
             <div class="toggle-wrap">
-                <div class="fxtwitter-toggle">
-                    <p class="fx-enable">Enable fxtwitter</p>
+                <div class="options-toggle">
+                    <p class="toggle-enable">Enable fxtwitter</p>
                     <input type="checkbox" id="switch" />
                     <label  for="switch">Toggle</label>
                 </div>
-                <div class="fx-description">
+                <div class="toggle-description">
                     <p>
                     Uses <b>fxtwitter</b> links instead of <b>vxtwitter</b>
                     </p>
                 </div>
             </div>
-            
+            <div class="toggle-wrap">
+                <div class="options-toggle">
+                    <p class="toggle-enable">Modify on copy</p>
+                    <input type="checkbox" id="oncopy-switch" />
+                    <label  for="oncopy-switch">On copy toggle</label>
+                </div>
+                <div class="toggle-description oncopy-description">
+                    <p>
+                    Modifies links directly on copy (Ctrl + C) instead of the custom command
+                    </p>
+                </div>
+            </div>
             
         </div>
     </div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,9 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   var fxtwitterButton = document.getElementById('switch');
+  var onCopyButton = document.getElementById('oncopy-switch');
 
   chrome.storage.sync.get('fxenabled', result => {
     if (result.fxenabled != null) {
-      console.log('get fx enable');
       fxtwitterButton.checked = result.fxenabled;
     }
   });
@@ -11,6 +11,18 @@ document.addEventListener('DOMContentLoaded', () => {
   fxtwitterButton.addEventListener('click', () => {
     chrome.storage.sync.set({ fxenabled: fxtwitterButton.checked }, () => {
       console.log('fx enabled');
+    });
+  });
+
+  chrome.storage.sync.get('oncopyenabled', result => {
+    if (result.oncopyenabled != null) {
+      onCopyButton.checked = result.oncopyenabled;
+    }
+  });
+
+  onCopyButton.addEventListener('click', () => {
+    chrome.storage.sync.set({ oncopyenabled: onCopyButton.checked }, () => {
+      console.log('oncopy enabled');
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR aims to add the feature to modify twitter links to `vxtwitter` or `fxtwitter` directly on copy command `Ctrl + C` instead of custom command.


