### PR TITLE
Fix to issue #7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "xify",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "A chrome extension that modifies twitter/x.com links to vxtwitter/fxtwitter on Copy/shortcut Ctrl+Shift+K and copies to clipboard.",
     "permissions": ["clipboardWrite", "activeTab", "storage"],
     "content_scripts": [

--- a/src/copy.js
+++ b/src/copy.js
@@ -10,6 +10,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 document.addEventListener('copy', e => {
   currentLink = document.location.href;
 
+  /* When the user visits the bookmarks page, and uses copy link button on a post, 
+    extension gets the url of the bookmarks page isntead of the post.
+    This is a temprary fix to get the url of the post instead.*/
+
+  // TODO: Check more pages where this could be an issue.
+  if (currentLink.includes('bookmarks')) {
+    const postLink = e.target.innerHTML;
+    const urlRegex = /^https?:\/\/[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(\/.*)?$/g;
+    if (postLink.match(urlRegex)) {
+      currentLink = postLink;
+    }
+  }
+
   chrome.storage.sync.get('oncopyenabled', isOnCopyEnabled => {
     if (
       isOnCopyEnabled != null &&
@@ -22,7 +35,10 @@ document.addEventListener('copy', e => {
 });
 
 const updateLink = clipboardData => {
-  var modifiedLink = clipboardData.replace(/twitter\.com|x\.com/g, 'vxtwitter.com');
+  var modifiedLink = clipboardData.replace(
+    /twitter\.com|x\.com/g,
+    'vxtwitter.com'
+  );
 
   chrome.storage.sync.get('fxenabled', isFxEnabled => {
     if (
@@ -30,7 +46,10 @@ const updateLink = clipboardData => {
       isFxEnabled.fxenabled != undefined &&
       isFxEnabled.fxenabled
     ) {
-      modifiedLink = clipboardData.replace(/twitter\.com|x\.com/g, 'fxtwitter.com');
+      modifiedLink = clipboardData.replace(
+        /twitter\.com|x\.com/g,
+        'fxtwitter.com'
+      );
     }
 
     navigator.clipboard.writeText(modifiedLink).then(


### PR DESCRIPTION
This PR aims to fix the issue #7. After merging this, when a user goes to bookmarks page and uses "copy link" button on a post, the modified post link (vxtwitter/fxtwittter) will be copied clipboard. However, if `Ctrl + C` is used the extension will still copy the bookmarks page url to the clipboard.